### PR TITLE
added double quotes to curl addresses where appropriate

### DIFF
--- a/docs/api/beam/analysis-groups/create-an-analysis-group.md
+++ b/docs/api/beam/analysis-groups/create-an-analysis-group.md
@@ -49,7 +49,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X POST https://api.predicthq.com/v1/beam/analysis-groups \
+curl -X POST "https://api.predicthq.com/v1/beam/analysis-groups" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN" \
      --data @<(cat <<EOF

--- a/docs/api/beam/analysis-groups/delete-an-analysis-group.md
+++ b/docs/api/beam/analysis-groups/delete-an-analysis-group.md
@@ -25,7 +25,7 @@ If successful, the HTTP response code will be `202 Accepted`.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X DELETE https://api.predicthq.com/v1/beam/analysis-groups/$GROUP_ID \
+curl -X DELETE "https://api.predicthq.com/v1/beam/analysis-groups/$GROUP_ID" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 {% endtab %}

--- a/docs/api/beam/analysis-groups/get-aggregated-feature-importance.md
+++ b/docs/api/beam/analysis-groups/get-aggregated-feature-importance.md
@@ -133,7 +133,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/beam/analysis-groups/$GROUP_ID/feature-importance \
+curl -X GET "https://api.predicthq.com/v1/beam/analysis-groups/$GROUP_ID/feature-importance" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/beam/analysis-groups/get-an-analysis-group.md
+++ b/docs/api/beam/analysis-groups/get-an-analysis-group.md
@@ -88,7 +88,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/beam/analysis-groups/$GROUP_ID \
+curl -X GET "https://api.predicthq.com/v1/beam/analysis-groups/$GROUP_ID" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/beam/analysis-groups/partially-update-an-analysis-group.md
+++ b/docs/api/beam/analysis-groups/partially-update-an-analysis-group.md
@@ -39,7 +39,7 @@ If successful, the HTTP response code will be `202 Accepted`.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X PATCH https://api.predicthq.com/v1/beam/analysis-groups/$GROUP_ID \
+curl -X PATCH "https://api.predicthq.com/v1/beam/analysis-groups/$GROUP_ID" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN" \
      --data @<(cat <<EOF

--- a/docs/api/beam/analysis-groups/refresh-an-analysis-group.md
+++ b/docs/api/beam/analysis-groups/refresh-an-analysis-group.md
@@ -25,7 +25,7 @@ If successful, the HTTP response code will be `202 Accepted`.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X POST https://api.predicthq.com/v1/beam/analysis-groups/$GROUP_ID/refresh \
+curl -X POST "https://api.predicthq.com/v1/beam/analysis-groups/$GROUP_ID/refresh" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/beam/analysis-groups/search-analysis-groups.md
+++ b/docs/api/beam/analysis-groups/search-analysis-groups.md
@@ -65,7 +65,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/beam/analysis-groups?status=active&sort=updated \
+curl -X GET "https://api.predicthq.com/v1/beam/analysis-groups?status=active&sort=updated" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/beam/analysis-groups/update-an-analysis-group.md
+++ b/docs/api/beam/analysis-groups/update-an-analysis-group.md
@@ -37,7 +37,7 @@ If successful, the HTTP response code will be `202 Accepted`.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X PUT https://api.predicthq.com/v1/beam/analysis-groups/$GROUP_ID \
+curl -X PUT "https://api.predicthq.com/v1/beam/analysis-groups/$GROUP_ID" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN" \
      --data @<(cat <<EOF

--- a/docs/api/beam/create-an-analysis.md
+++ b/docs/api/beam/create-an-analysis.md
@@ -62,7 +62,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X POST https://api.predicthq.com/v1/beam/analyses \
+curl -X POST "https://api.predicthq.com/v1/beam/analyses" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN" \
      --data @<(cat <<EOF

--- a/docs/api/beam/delete-an-analysis.md
+++ b/docs/api/beam/delete-an-analysis.md
@@ -24,7 +24,7 @@ If successful, the HTTP response code will be `202 Accepted`.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X DELETE https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID \
+curl -X DELETE "https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 {% endtab %}

--- a/docs/api/beam/get-an-analysis.md
+++ b/docs/api/beam/get-an-analysis.md
@@ -122,7 +122,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID \
+curl -X GET "https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/beam/get-correlation.md
+++ b/docs/api/beam/get-correlation.md
@@ -93,7 +93,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID/correlate?date.gte=2022-01-01&date.lte=2022-12-31 \
+curl -X GET "https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID/correlate?date.gte=2022-01-01&date.lte=2022-12-31" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/beam/get-feature-importance.md
+++ b/docs/api/beam/get-feature-importance.md
@@ -106,7 +106,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID/feature-importance \
+curl -X GET "https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID/feature-importance" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/beam/partially-update-an-analysis.md
+++ b/docs/api/beam/partially-update-an-analysis.md
@@ -38,7 +38,7 @@ If successful, the HTTP response code will be `204 No Content`.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X PATCH https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID \
+curl -X PATCH "https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN" \
      --data @<(cat <<EOF

--- a/docs/api/beam/refresh-an-analysis.md
+++ b/docs/api/beam/refresh-an-analysis.md
@@ -24,7 +24,7 @@ If successful, the HTTP response code will be `202 Accepted`.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X POST https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID/refresh \
+curl -X POST "https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID/refresh" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/beam/search-analyses.md
+++ b/docs/api/beam/search-analyses.md
@@ -84,7 +84,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/beam/analyses?status=draft&sort=updated \
+curl -X GET "https://api.predicthq.com/v1/beam/analyses?status=draft&sort=updated" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/beam/update-an-analysis.md
+++ b/docs/api/beam/update-an-analysis.md
@@ -38,7 +38,7 @@ If successful, the HTTP response code will be `204 No Content`.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X PUT https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID \
+curl -X PUT "https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN" \
      --data @<(cat <<EOF

--- a/docs/api/beam/upload-demand-data.md
+++ b/docs/api/beam/upload-demand-data.md
@@ -106,7 +106,7 @@ If successful, the HTTP response code will be `202 Accepted`.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X POST https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID/sink \
+curl -X POST "https://api.predicthq.com/v1/beam/analyses/$ANALYSIS_ID/sink" \
      -H "Content-Type: text/csv" \
      -H "Authorization: Bearer $ACCESS_TOKEN" \
      --data @data.csv

--- a/docs/api/broadcasts/get-broadcasts-count.md
+++ b/docs/api/broadcasts/get-broadcasts-count.md
@@ -39,7 +39,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/broadcasts/count/?event.event_id=AdKtL974inQB7GURRd \
+curl -X GET "https://api.predicthq.com/v1/broadcasts/count/?event.event_id=AdKtL974inQB7GURRd" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
@@ -64,4 +64,3 @@ print(response.json())
 ```
 {% endtab %}
 {% endtabs %}
-

--- a/docs/api/broadcasts/search-broadcasts.md
+++ b/docs/api/broadcasts/search-broadcasts.md
@@ -194,7 +194,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/broadcasts/?broadcast_id=u5aCvebffuNFpGSGNQFiU4 \
+curl -X GET "https://api.predicthq.com/v1/broadcasts/?broadcast_id=u5aCvebffuNFpGSGNQFiU4" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/demand-surge/get-demand-surges.md
+++ b/docs/api/demand-surge/get-demand-surges.md
@@ -60,7 +60,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/demand-surge/?date_from=2021-05-12&min_surge_intensity=m&location.place_id=2643743 \
+curl -X GET "https://api.predicthq.com/v1/demand-surge/?date_from=2021-05-12&min_surge_intensity=m&location.place_id=2643743" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/events/get-event-counts.md
+++ b/docs/api/events/get-event-counts.md
@@ -205,7 +205,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/events/count/?country=NZ \
+curl -X GET "https://api.predicthq.com/v1/events/count/?country=NZ" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
@@ -230,4 +230,3 @@ print(response.json())
 ```
 {% endtab %}
 {% endtabs %}
-

--- a/docs/api/events/search-events.md
+++ b/docs/api/events/search-events.md
@@ -342,7 +342,7 @@ Below is an example of a single result.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/events/?id=5uRg7CqGu7DTtu4Rfk \
+curl -X GET "https://api.predicthq.com/v1/events/?id=5uRg7CqGu7DTtu4Rfk" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
@@ -375,4 +375,3 @@ Below are some guides relevant to this API:
 * [Geolocation Guides](../../getting-started/guides/geolocation-guides/)
 * [Date and Time Guides](../../getting-started/guides/date-and-time-guides/)
 * Other [Event API Guides](../../getting-started/guides/events-api-guides/)
-

--- a/docs/api/features/get-features.md
+++ b/docs/api/features/get-features.md
@@ -447,7 +447,7 @@ The same data represented as a table:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X POST https://api.predicthq.com/v1/features/ \
+curl -X POST "https://api.predicthq.com/v1/features/" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN" \
      --data @<(cat <<EOF

--- a/docs/api/loop/loop-feedback/search-feedback.md
+++ b/docs/api/loop/loop-feedback/search-feedback.md
@@ -115,7 +115,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/loop/feedback/conversations?link_id=m4Dk4g4DRA8Yqbp2PC54 \
+curl -X GET "https://api.predicthq.com/v1/loop/feedback/conversations?link_id=m4Dk4g4DRA8Yqbp2PC54" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/loop/loop-links/create-a-loop-link.md
+++ b/docs/api/loop/loop-links/create-a-loop-link.md
@@ -62,7 +62,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X POST https://api.predicthq.com/v1/loop/links \
+curl -X POST "https://api.predicthq.com/v1/loop/links" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN" \
      --data @<(cat <<EOF

--- a/docs/api/loop/loop-links/delete-a-loop-link.md
+++ b/docs/api/loop/loop-links/delete-a-loop-link.md
@@ -24,7 +24,7 @@ If successful, the HTTP response code will be `204 No Content`.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X DELETE https://api.predicthq.com/v1/loop/links/$LINK_ID \
+curl -X DELETE "https://api.predicthq.com/v1/loop/links/$LINK_ID" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 {% endtab %}

--- a/docs/api/loop/loop-links/get-a-loop-link.md
+++ b/docs/api/loop/loop-links/get-a-loop-link.md
@@ -54,7 +54,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/loop/links/$LINK_ID \
+curl -X GET "https://api.predicthq.com/v1/loop/links/$LINK_ID" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/loop/loop-links/search-loop-links.md
+++ b/docs/api/loop/loop-links/search-loop-links.md
@@ -60,7 +60,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/loop/links?sort=name \
+curl -X GET "https://api.predicthq.com/v1/loop/links?sort=name" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/loop/loop-links/update-a-loop-link.md
+++ b/docs/api/loop/loop-links/update-a-loop-link.md
@@ -36,7 +36,7 @@ If successful, the HTTP response code will be `204 No Content`.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X PUT https://api.predicthq.com/v1/loop/links/$LINK_ID \
+curl -X PUT "https://api.predicthq.com/v1/loop/links/$LINK_ID" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN" \
      --data @<(cat <<EOF

--- a/docs/api/loop/loop-settings/get-loop-settings.md
+++ b/docs/api/loop/loop-settings/get-loop-settings.md
@@ -41,7 +41,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/loop/settings \
+curl -X GET "https://api.predicthq.com/v1/loop/settings" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/loop/loop-settings/update-loop-settings.md
+++ b/docs/api/loop/loop-settings/update-loop-settings.md
@@ -29,7 +29,7 @@ If successful, the HTTP response code will be `204 No Content`.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X PUT https://api.predicthq.com/v1/loop/settings \
+curl -X PUT "https://api.predicthq.com/v1/loop/settings" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN" \
      --data @<(cat <<EOF

--- a/docs/api/loop/loop-submissions/search-submitted-events.md
+++ b/docs/api/loop/loop-submissions/search-submitted-events.md
@@ -34,7 +34,7 @@ print(response.json())
 
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/loop/events?phq_review=approved \
+curl -X GET "https://api.predicthq.com/v1/loop/events?phq_review=approved" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/overview/authenticating.md
+++ b/docs/api/overview/authenticating.md
@@ -5,7 +5,7 @@ All PredictHQ API endpoints require authentication. You can authenticate your re
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/events/ \
+curl -X GET "https://api.predicthq.com/v1/events/" \
      -H "Authorization: Bearer $ACCESS_TOKEN" 
 ```
 {% endtab %}

--- a/docs/api/places/get-place-hierarchies.md
+++ b/docs/api/places/get-place-hierarchies.md
@@ -107,7 +107,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/places/hierarchies/?location.origin=47.615337,-122.203981 \
+curl -X GET "https://api.predicthq.com/v1/places/hierarchies/?location.origin=47.615337,-122.203981" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/places/search-places.md
+++ b/docs/api/places/search-places.md
@@ -109,7 +109,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/places/?q=New+York&limit=5 \
+curl -X GET "https://api.predicthq.com/v1/places/?q=New+York&limit=5" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/docs/api/saved-locations/delete-a-saved-location.md
+++ b/docs/api/saved-locations/delete-a-saved-location.md
@@ -24,7 +24,7 @@ If successful, the HTTP response code will be `202 Accepted`.
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X DELETE https://api.predicthq.com/v1/saved-locations/$LOCATION_ID \
+curl -X DELETE "https://api.predicthq.com/v1/saved-locations/$LOCATION_ID" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 {% endtab %}

--- a/docs/api/suggested-radius/get-suggested-radius.md
+++ b/docs/api/suggested-radius/get-suggested-radius.md
@@ -64,7 +64,7 @@ Below is an example response:
 {% tabs %}
 {% tab title="curl" %}
 ```bash
-curl -X GET https://api.predicthq.com/v1/suggested-radius/?location.origin=37.747767,-122.455320&industry=parking&radius_unit=km \
+curl -X GET "https://api.predicthq.com/v1/suggested-radius/?location.origin=37.747767,-122.455320&industry=parking&radius_unit=km" \
      -H "Accept: application/json" \
      -H "Authorization: Bearer $ACCESS_TOKEN"
 ```


### PR DESCRIPTION
In order to work on ZSH many of the URLs in the curl examples needed to be quoted.