### PR TITLE
Update example events to link to public events pages

### DIFF
--- a/docs/tech-docs/getting-started/guides/events-api-guides/attendance-based-events-data-science-guides.md
+++ b/docs/tech-docs/getting-started/guides/events-api-guides/attendance-based-events-data-science-guides.md
@@ -1,6 +1,6 @@
 # Attendance-Based Events Notebooks
 
-Attended Events are gatherings with a start and end date and time, where people come together in one location for entertainment or business, take the [2020 Super Bowl](https://control.predicthq.com/search/events/svbfg9xT4YSVUeeAKp) game or [San Diego Comic-Con](https://control.predicthq.com/search/events/yaREpZVlOX1P) as an example. PredictHQ uses machine-learning models to predict attendance and ranks for each of these events. This content is provided as a resource for Data Science teams to help get them up and running quickly.
+Attended Events are gatherings with a start and end date and time, where people come together in one location for entertainment or business, take the [2020 Super Bowl](https://events.predicthq.com/events/svbfg9xT4YSVUeeAKp) game or [San Diego Comic-Con](https://events.predicthq.com/events/yaREpZVlOX1P) as an example. PredictHQ uses machine-learning models to predict attendance and ranks for each of these events. This content is provided as a resource for Data Science teams to help get them up and running quickly.
 
 We provide guides to using our API and data with common Data Science tools and libraries in Python. The articles include a link to Jupyter Notebooks that you can download and run. The guides include code samples and instructions for performing common tasks.
 

--- a/docs/tech-docs/getting-started/predicthq-data/event-categories/attendance-based-events.md
+++ b/docs/tech-docs/getting-started/predicthq-data/event-categories/attendance-based-events.md
@@ -44,7 +44,7 @@ Note: datetime is in UTC.
 
 #### Location
 
-Sports events are usually point events, meaning the latitude and longitude of the event represent the location of the event’s venue. The event can also impact an area or region, for example, the location of the [2016 Rio Summer Olympics](https://control.predicthq.com/search/events/VMDqfHDg3PAbxL3PXh) is the state of Rio de Janeiro.
+Sports events are usually point events, meaning the latitude and longitude of the event represent the location of the event’s venue. The event can also impact an area or region, for example, the location of the [2016 Rio Summer Olympics](https://events.predicthq.com/events/VMDqfHDg3PAbxL3PXh) is the state of Rio de Janeiro.
 
 #### Entities
 
@@ -66,17 +66,17 @@ Sports events have PHQ Attendance available.
 
 ### Conferences
 
-A formal meeting or forum relating to a certain topic between a group of people with shared interests. A major conference, especially an industry-related one, may last for several days and occur with regular frequency. An example of an annually occurring conference is the [ASH Annual Meeting](https://control.predicthq.com/search/events/2RxTdCucMNcLZSsEqW).
+A formal meeting or forum relating to a certain topic between a group of people with shared interests. A major conference, especially an industry-related one, may last for several days and occur with regular frequency. An example of an annually occurring conference is the [ASH Annual Meeting](https://events.predicthq.com/events/2RxTdCucMNcLZSsEqW).
 
 **LABELS**
 
 Labels for a conference event provide more information about the event. The most common 5 labels are:
 
-1. `business`: The conferences for a commercial purpose, for example, [Dreamforce](https://control.predicthq.com/search/events/HAnRjF9RUX8yFnWuGv) by Salesforce.
-2. `education`: The conferences for an educational purpose, for example, [Young Social Innovators of the Year Awards](https://control.predicthq.com/search/events/XoEPm68yHWWNw9ysDp).
-3. `health`: The conferences related to the health industry, for example, [CIOSP - Congresso Internacional de Odontologia de São Paulo](https://control.predicthq.com/search/events/kJ76dr1RmWPP).
-4. `technology`: The conferences related to the technology topic, for example, [FPD China](https://control.predicthq.com/search/events/YEKd1jV29rjV).
-5. `science`: The conferences related to the scientific topic, for example, [IAPM ASM](https://control.predicthq.com/search/events/RSJcHToM4Jy5MQcHZJ).
+1. `business`: The conferences for a commercial purpose, for example, [Dreamforce](https://events.predicthq.com/events/HAnRjF9RUX8yFnWuGv) by Salesforce.
+2. `education`: The conferences for an educational purpose, for example, [Young Social Innovators of the Year Awards](https://events.predicthq.com/events/XoEPm68yHWWNw9ysDp).
+3. `health`: The conferences related to the health industry, for example, [CIOSP - Congresso Internacional de Odontologia de São Paulo](https://events.predicthq.com/events/kJ76dr1RmWPP).
+4. `technology`: The conferences related to the technology topic, for example, [FPD China](https://events.predicthq.com/events/YEKd1jV29rjV).
+5. `science`: The conferences related to the scientific topic, for example, [IAPM ASM](https://events.predicthq.com/events/RSJcHToM4Jy5MQcHZJ).
 
 #### Date & Time
 
@@ -114,11 +114,11 @@ An industrial exhibition for communicating and trading purpose between business,
 
 Labels for an expo event provide more information about the event. The most common 5 labels are:
 
-1. `education`: The expos for an educational purpose or education-related topics, for example, [Riyadh International Book Fair](https://control.predicthq.com/search/events/cL7mv3QVd4PAwaRbvU).
-2. `technology`: The expos related to topics in technology, for example, [IIMS - Indonesia International Motor Show](https://control.predicthq.com/search/events/SDxxc8XymZGYWZ6nrX).
-3. `performing-arts`: The shows or fairs that have live performances or are art-related, for example, [Wizard World Comic Con](https://control.predicthq.com/search/events/i3VNEqMuZKpXUoBusH), and [Saint Louis Art Fair](https://control.predicthq.com/search/events/9uQWg42s8RziqNxPQb).
-4. `entertainment`: The shows or fairs for entertainment purposes, for example, [The Big E (The Eastern States Exposition)](https://control.predicthq.com/search/events/gPmLe5eSMCbjLnYWCg).
-5. `career`: A career or job fair that includes a number of businesses as well large numbers of candidates , for example, [HKTDC Education & Careers Expo](https://control.predicthq.com/search/events/ZkwcdaWxiMtbKZMrPK).
+1. `education`: The expos for an educational purpose or education-related topics, for example, [Riyadh International Book Fair](https://events.predicthq.com/events/cL7mv3QVd4PAwaRbvU).
+2. `technology`: The expos related to topics in technology, for example, [IIMS - Indonesia International Motor Show](https://events.predicthq.com/events/SDxxc8XymZGYWZ6nrX).
+3. `performing-arts`: The shows or fairs that have live performances or are art-related, for example, [Wizard World Comic Con](https://events.predicthq.com/events/i3VNEqMuZKpXUoBusH), and [Saint Louis Art Fair](https://events.predicthq.com/events/9uQWg42s8RziqNxPQb).
+4. `entertainment`: The shows or fairs for entertainment purposes, for example, [The Big E (The Eastern States Exposition)](https://events.predicthq.com/events/gPmLe5eSMCbjLnYWCg).
+5. `career`: A career or job fair that includes a number of businesses as well large numbers of candidates , for example, [HKTDC Education & Careers Expo](https://events.predicthq.com/events/ZkwcdaWxiMtbKZMrPK).
 
 #### Date & Time
 
@@ -150,7 +150,7 @@ Expos events have PHQ Attendance available.
 
 ### Concerts
 
-A musical performance where the primary intention of attendance is to see the musical artist or listen to music. Concerts usually last less than one day. Examples are a large [Eminem](https://control.predicthq.com/search/events/aYR4t59pGHA92FtNgK) concert, or a smaller nightclub event, for example, [Darude At Hq2 Nightclub Atlantic City](https://control.predicthq.com/search/events/xx8TPFE7XNh5pdxyRX).
+A musical performance where the primary intention of attendance is to see the musical artist or listen to music. Concerts usually last less than one day. Examples are a large [Eminem](https://events.predicthq.com/events/aYR4t59pGHA92FtNgK) concert, or a smaller nightclub event, for example, [Darude At Hq2 Nightclub Atlantic City](https://events.predicthq.com/events/xx8TPFE7XNh5pdxyRX).
 
 **LABELS**
 
@@ -186,17 +186,17 @@ Concerts events have PHQ Attendance available.
 
 ### Festivals
 
-A commonly known day or a period of time when people gather together to celebrate a specific reason; or a day or a period of time consisting of an organized series of shows and entertainment activities Festivals typically occur on a certain frequency. For example, the [Yosakoi Soran Festival](https://control.predicthq.com/search/events/ScR7u7EZSBuxZ8kK9J) is held annually.
+A commonly known day or a period of time when people gather together to celebrate a specific reason; or a day or a period of time consisting of an organized series of shows and entertainment activities Festivals typically occur on a certain frequency. For example, the [Yosakoi Soran Festival](https://events.predicthq.com/events/ScR7u7EZSBuxZ8kK9J) is held annually.
 
 **LABELS**
 
 Labels for a festival event provide more information about the festival. The most common 5 labels are:
 
-1. `music`: Music festivals when a large group of musical artists continuously perform over several days. Music festivals are usually held at a dedicated venue that can fit a large number of attendees, for example, the [Ultra Music Festival](https://control.predicthq.com/search/events/duHrbmUbpFSgwypGAK).
-2. `performing-arts`: The festivals that consist of performing shows such as a costume parade or a fireworks show. Such festivals could feature traditional music, theatre, poetry and art. For example, the [National Festival of Popular Arts in Marrakech](https://control.predicthq.com/search/events/cxSrjK82oWZGUWUvUJ).
-3. `family`: The festivals which are family-friendly and children-friendly, for example, [Magnificent Mile Lights Festival](https://control.predicthq.com/search/events/vFQK4H3yaujGqwnR4z).
-4. `community`: Traditional festivals in the local area. Community festivals are less formal than world-wide festivals and may also include street markets and entertainment activities. The [Odunde Festival](https://control.predicthq.com/search/events/dkbGjQW943KSL5hT8b) is an example of a community festival.
-5. `food`: Food festivals where communities or businesses trade food products, for example, [Bite of Seattle](https://control.predicthq.com/search/events/QDgCysY3kMnpoGYFi9).
+1. `music`: Music festivals when a large group of musical artists continuously perform over several days. Music festivals are usually held at a dedicated venue that can fit a large number of attendees, for example, the [Ultra Music Festival](https://events.predicthq.com/events/duHrbmUbpFSgwypGAK).
+2. `performing-arts`: The festivals that consist of performing shows such as a costume parade or a fireworks show. Such festivals could feature traditional music, theatre, poetry and art. For example, the [National Festival of Popular Arts in Marrakech](https://events.predicthq.com/events/cxSrjK82oWZGUWUvUJ).
+3. `family`: The festivals which are family-friendly and children-friendly, for example, [Magnificent Mile Lights Festival](https://events.predicthq.com/events/vFQK4H3yaujGqwnR4z).
+4. `community`: Traditional festivals in the local area. Community festivals are less formal than world-wide festivals and may also include street markets and entertainment activities. The [Odunde Festival](https://events.predicthq.com/events/dkbGjQW943KSL5hT8b) is an example of a community festival.
+5. `food`: Food festivals where communities or businesses trade food products, for example, [Bite of Seattle](https://events.predicthq.com/events/QDgCysY3kMnpoGYFi9).
 
 #### Date & Time
 
@@ -206,7 +206,7 @@ Note: datetime is in UTC.
 
 #### Location
 
-A festival event can be a point event or an area event. The latitude and longitude of a point event represents the location of the venue where the festival takes place. The latitude and longitude of an area event is the geometric center of the area of the festival - either the area impacted by the festival, or an area where the festival takes place since its location is not fixed. An example of a festival without a fixed location is the [Norwich St. Patrick’s Day Parade and Festival](https://control.predicthq.com/search/events/w5PNZxwvKAKLGXGrae).
+A festival event can be a point event or an area event. The latitude and longitude of a point event represents the location of the venue where the festival takes place. The latitude and longitude of an area event is the geometric center of the area of the festival - either the area impacted by the festival, or an area where the festival takes place since its location is not fixed. An example of a festival without a fixed location is the [Norwich St. Patrick’s Day Parade and Festival](https://events.predicthq.com/events/w5PNZxwvKAKLGXGrae).
 
 #### Entities
 
@@ -228,7 +228,7 @@ Festival events have PHQ Attendance available.
 
 ### Performing Arts
 
-A show or an exhibition of creative activities for an audience, for example, [a circus show](https://control.predicthq.com/search/events/EHKbvvKhLnVonwUUbD).
+A show or an exhibition of creative activities for an audience, for example, [a circus show](https://events.predicthq.com/events/EHKbvvKhLnVonwUUbD).
 
 **EVENT TYPES**
 
@@ -236,19 +236,19 @@ The most common 5 types of performing-arts events are:
 
 1.  **General Theatre**
 
-    Theatre plays, for example, [The Nutcracker ballet show](https://control.predicthq.com/search/events/wunsQfMcMgbB2wXedq).
+    Theatre plays, for example, [The Nutcracker ballet show](https://events.predicthq.com/events/wunsQfMcMgbB2wXedq).
 2.  **Comedy club**
 
-    Standup comedy shows, for example, [Eddie Izzard - Wunderbar World Tour](https://control.predicthq.com/search/events/k2bibyMXE4B42EECnv).
+    Standup comedy shows, for example, [Eddie Izzard - Wunderbar World Tour](https://events.predicthq.com/events/k2bibyMXE4B42EECnv).
 3.  **Concert**
 
-    Musical plays, for example, A [symphony](https://control.predicthq.com/search/events/MeswVtp3dMccSx5jEs), or an [opera](https://control.predicthq.com/search/events/ah6hg4UorgsaJ2PSFY), etc.
+    Musical plays, for example, A [symphony](https://events.predicthq.com/events/MeswVtp3dMccSx5jEs), or an [opera](https://events.predicthq.com/events/ah6hg4UorgsaJ2PSFY), etc.
 4.  **Family Theatre**
 
-    Shows or plays where the main audience are children, for example, [Magic On Ice](https://control.predicthq.com/search/events/8QJfuDQeqrKQftBnB3), a [dubbing show](https://control.predicthq.com/search/events/sjg2xuf27oeLQLrbpt), etc.
+    Shows or plays where the main audience are children, for example, [Magic On Ice](https://events.predicthq.com/events/8QJfuDQeqrKQftBnB3), a [dubbing show](https://events.predicthq.com/events/sjg2xuf27oeLQLrbpt), etc.
 5.  **Cultural Performances**
 
-    Traditional or cultural activities, for example, [Sewing & Quilt Expo](https://control.predicthq.com/search/events/NCErdrvw9R69ocqES9), a [poetry slam](https://control.predicthq.com/search/events/CEE7SzC2CmrWSbbDe4), etc.
+    Traditional or cultural activities, for example, [Sewing & Quilt Expo](https://events.predicthq.com/events/NCErdrvw9R69ocqES9), a [poetry slam](https://events.predicthq.com/events/CEE7SzC2CmrWSbbDe4), etc.
 
 #### Date & Time
 
@@ -280,17 +280,17 @@ Performing-arts events have PHQ Attendance available.
 
 ### Community
 
-This category includes various types of events, for example, a [college event](https://control.predicthq.com/search/events/7diCQtRZ5XQdso27v3), a [community party](https://control.predicthq.com/search/events/pS49Cvk4tiSPKdEAJ8), an [auction](https://control.predicthq.com/search/events/iC5BK62w3z9CLpqvif), or a [fan meeting](https://control.predicthq.com/search/events/CnNAFhLqffMQMsqg4R).
+This category includes various types of events, for example, a [college event](https://events.predicthq.com/events/7diCQtRZ5XQdso27v3), a [community party](https://events.predicthq.com/events/pS49Cvk4tiSPKdEAJ8), an [auction](https://events.predicthq.com/events/iC5BK62w3z9CLpqvif), or a [fan meeting](https://events.predicthq.com/events/CnNAFhLqffMQMsqg4R).
 
 **LABELS**
 
 Labels for a community event provide more information about the event. The most common 5 labels are:
 
-1. `music`, `concert`: Social events with musical activity, for example, a [karaoke at a bar](https://control.predicthq.com/search/events/TvzBomhs9m6JAdKRr3).
-2. `family`: Community events which are children and family-friendly, for example, a [book club breakfast in the library](https://control.predicthq.com/search/events/3pTSHhuXjQErhg9nwu).
-3. `food`: Social events about food or have food provided, for example, a [wine tasting event](https://control.predicthq.com/search/events/hk9SqnMEk2ywVAyQb9).
-4. `education`: Informal training workshops or clubs that consist of a group of people that share the same interest, for example, an [installation art workshop](https://control.predicthq.com/search/events/9sGedbBiSzq74ERvkS).
-5. `fundraiser`: Community [fundraising](https://control.predicthq.com/search/events/U7nFaVDxKEh6RAD5UD) events.
+1. `music`, `concert`: Social events with musical activity, for example, a [karaoke at a bar](https://events.predicthq.com/events/TvzBomhs9m6JAdKRr3).
+2. `family`: Community events which are children and family-friendly, for example, a [book club breakfast in the library](https://events.predicthq.com/events/3pTSHhuXjQErhg9nwu).
+3. `food`: Social events about food or have food provided, for example, a [wine tasting event](https://events.predicthq.com/events/hk9SqnMEk2ywVAyQb9).
+4. `education`: Informal training workshops or clubs that consist of a group of people that share the same interest, for example, an [installation art workshop](https://events.predicthq.com/events/9sGedbBiSzq74ERvkS).
+5. `fundraiser`: Community [fundraising](https://events.predicthq.com/events/U7nFaVDxKEh6RAD5UD) events.
 
 #### Date & Time
 

--- a/docs/tech-docs/getting-started/predicthq-data/event-categories/live-tv-events.md
+++ b/docs/tech-docs/getting-started/predicthq-data/event-categories/live-tv-events.md
@@ -7,7 +7,7 @@ description: >-
 
 # Live TV Events
 
-For example, during the basketball game [Villanova Wildcats vs Baylor Bears](https://control.predicthq.com/search/events/3pgcB4kTQdLv6FAhCb#broadcasts) on March 27, 2021, there were over 150,000 people in Cook County, Illinois watching the live broadcast of the basketball game, as well as over 130,000 people were watching the game in Los Angeles County, California, etc.
+For example, during the basketball game [Villanova Wildcats vs Baylor Bears](https://events.predicthq.com/events/3pgcB4kTQdLv6FAhCb) on March 27, 2021, there were over 150,000 people in Cook County, Illinois watching the live broadcast of the basketball game, as well as over 130,000 people were watching the game in Los Angeles County, California, etc.
 
 **Note**: Live TV Events covers live games. Replays of sporting events are not included.
 

--- a/docs/tech-docs/getting-started/predicthq-data/event-categories/non-attendance-based-events.md
+++ b/docs/tech-docs/getting-started/predicthq-data/event-categories/non-attendance-based-events.md
@@ -18,15 +18,15 @@ A holiday generally established and recognized by law when most businesses and s
 
 Labels for a public holiday event provide more information about the holiday. The most common 5 labels are:
 
-1. `holiday-national`: When the day is celebrated on a country level, e.g. the entire country was celebrating [Martin Luther King Jr. Day](https://control.predicthq.com/search/events/rXRfgke2wuD2zv55H7) on Jan 18, 2021
-2. `holiday-local-common`: When the holiday is celebrated in only some regions of the country. E.g. only 5 out of 13 provinces and territories of Canada ([British Columbia](https://control.predicthq.com/search/events/KAojdY57MdQqYKYJvf), [Alberta](https://control.predicthq.com/search/events/joBsZRtPMSCPaD9sTQ), [Ontario](https://control.predicthq.com/search/events/zG3Egb83333QcyviRL), [New Brunswick](https://control.predicthq.com/search/events/KoTZox2GDtA4nx3CBR), and [Saskatchewan](https://control.predicthq.com/search/events/uhTw7zBFdZjdPDSJHb)) celebrate Family Day on the first Monday in February.
-3. `holiday-local`: When the holiday is region-specific, e.g. only Texas state celebrates [Texas Independence Day](https://control.predicthq.com/search/events/kjqFBZH2qbzrswecDv) on Mar 2, 2021
-4. `holiday-religious`: When the holiday is celebrated for a religious reason, e.g. there are about 44 countries that celebrate [Eid al-Adha](https://control.predicthq.com/search/events/pYQSFxFcYgJJdzo3uc) Day
-5. `holiday-christian`: When the holiday is Christian related, e.g. [Corpus Christi](https://control.predicthq.com/search/events/3768MLSMzkSPo6HPjQ).
+1. `holiday-national`: When the day is celebrated on a country level, e.g. the entire country was celebrating [Martin Luther King Jr. Day](https://events.predicthq.com/events/rXRfgke2wuD2zv55H7) on Jan 18, 2021
+2. `holiday-local-common`: When the holiday is celebrated in only some regions of the country. E.g. only 5 out of 13 provinces and territories of Canada ([British Columbia](https://events.predicthq.com/events/KAojdY57MdQqYKYJvf), [Alberta](https://events.predicthq.com/events/joBsZRtPMSCPaD9sTQ), [Ontario](https://events.predicthq.com/events/zG3Egb83333QcyviRL), [New Brunswick](https://events.predicthq.com/events/KoTZox2GDtA4nx3CBR), and [Saskatchewan](https://events.predicthq.com/events/uhTw7zBFdZjdPDSJHb)) celebrate Family Day on the first Monday in February.
+3. `holiday-local`: When the holiday is region-specific, e.g. only Texas state celebrates [Texas Independence Day](https://events.predicthq.com/events/kjqFBZH2qbzrswecDv) on Mar 2, 2021
+4. `holiday-religious`: When the holiday is celebrated for a religious reason, e.g. there are about 44 countries that celebrate [Eid al-Adha](https://events.predicthq.com/events/pYQSFxFcYgJJdzo3uc) Day
+5. `holiday-christian`: When the holiday is Christian related, e.g. [Corpus Christi](https://events.predicthq.com/events/3768MLSMzkSPo6HPjQ).
 
 #### Date & Time
 
-<table><thead><tr><th width="224.33333333333331">Date &#x26; Time Fields</th><th width="154" align="center">Availability</th><th>Notes</th></tr></thead><tbody><tr><td>Start date</td><td align="center">Yes</td><td></td></tr><tr><td>End date</td><td align="center">No</td><td>Same as the start date. A public holiday event is a single-day event. There are no multi-day events under the public-holidays category. The holiday will break into individual days if it’s celebrated over multiple days, e.g. there are 4 days off in Japan during the New Year period, the four corresponded records are: <a href="https://control.predicthq.com/search/events/rxdV0A0GKg16">December 31 Bank Holiday</a>, <a href="https://control.predicthq.com/search/events/8fuH3RGXNfmVs2UGAm">New Year's Day</a>, <a href="https://control.predicthq.com/search/events/bwJoHe5AtFZpRHWQ9j">January 2 Bank Holiday</a>, <a href="https://control.predicthq.com/search/events/M4bAQVNwHuv3qwTsvd">January 3 Bank Holiday</a></td></tr><tr><td>Start time</td><td align="center">No</td><td></td></tr><tr><td>End time</td><td align="center">No</td><td></td></tr><tr><td>Timezone</td><td align="center">No</td><td></td></tr></tbody></table>
+<table><thead><tr><th width="224.33333333333331">Date &#x26; Time Fields</th><th width="154" align="center">Availability</th><th>Notes</th></tr></thead><tbody><tr><td>Start date</td><td align="center">Yes</td><td></td></tr><tr><td>End date</td><td align="center">No</td><td>Same as the start date. A public holiday event is a single-day event. There are no multi-day events under the public-holidays category. The holiday will break into individual days if it’s celebrated over multiple days, e.g. there are 4 days off in Japan during the New Year period, the four corresponded records are: <a href="https://events.predicthq.com/events/rxdV0A0GKg16">December 31 Bank Holiday</a>, <a href="https://events.predicthq.com/events/8fuH3RGXNfmVs2UGAm">New Year's Day</a>, <a href="https://events.predicthq.com/events/bwJoHe5AtFZpRHWQ9j">January 2 Bank Holiday</a>, <a href="https://events.predicthq.com/events/M4bAQVNwHuv3qwTsvd">January 3 Bank Holiday</a></td></tr><tr><td>Start time</td><td align="center">No</td><td></td></tr><tr><td>End time</td><td align="center">No</td><td></td></tr><tr><td>Timezone</td><td align="center">No</td><td></td></tr></tbody></table>
 
 Note: datetime is used with the local timezone. E.g. New York is celebrating New Year’s Day on January 1st EST, while San Francisco is also celebrating New Year’s Day on January 1st but in PST.
 
@@ -55,7 +55,7 @@ Public holidays have no PHQ Attendance available as the rank/impact only reflect
 
 ### School Holidays
 
-School holiday events represent the general date range in an area where the schools are closed for the term/semester break. E.g. [Easter School Holidays](https://control.predicthq.com/search/events/tbZtoYD9mnArGQs5RW) in Bavaria, Germany is from March 27th, 2021 to April 11th, 2021.
+School holiday events represent the general date range in an area where the schools are closed for the term/semester break. E.g. [Easter School Holidays](https://events.predicthq.com/events/tbZtoYD9mnArGQs5RW) in Bavaria, Germany is from March 27th, 2021 to April 11th, 2021.
 
 **Note**: The School holidays category covers the holiday dates in primary schools and secondary schools. School holidays for higher education institutions are under the [Academic Events](attendance-based-events.md#academic) category.
 
@@ -79,7 +79,7 @@ Note: Datetime is used with the local timezone.
 
 #### Location
 
-School holiday is an area event, it scopes to either locality, localadmin, county, region or country level, i.e. majority schools in that region commence break in that period. For example, school holidays in the United States are scoped to the county level, e.g. [Clark County School District - Spring Break](https://events.predicthq.com/events/G9dAga9g8vcacTgmB9) while school holidays in New Zealand are scoped to the country level which means we have one school holiday for the entire country, e.g. [Spring School Holidays](https://control.predicthq.com/search/events/SPVWqTnhTqry2rLDvf). School holidays in the UK are scoped to either region, county, or the local council (localadmin) level.
+School holiday is an area event, it scopes to either locality, localadmin, county, region or country level, i.e. majority schools in that region commence break in that period. For example, school holidays in the United States are scoped to the county level, e.g. [Clark County School District - Spring Break](https://events.predicthq.com/events/G9dAga9g8vcacTgmB9) while school holidays in New Zealand are scoped to the country level which means we have one school holiday for the entire country, e.g. [Spring School Holidays](https://events.predicthq.com/events/SPVWqTnhTqry2rLDvf). School holidays in the UK are scoped to either region, county, or the local council (localadmin) level.
 
 The latitude and longitude is pointing to the center of the region or country.
 
@@ -160,7 +160,7 @@ These Frequently asked questions apply to district level school holidays (for th
 1. **Does the data include private school holidays as well?** The data set does not cover private schools. Private schools select their own calendars and are not necessarily governed by school district dates. That being said, some private schools might follow similar calendars.
 2. **Does the data recognize if school holidays are changed due to covid-based government decisions?** The data will recognize changes as soon as possible. The events have an update date/time on them so we fetched updates based on these dates. We update events weekly.
 3. **What date range does the event signal? Are there start and end times to the school holiday?** The date range is the total length of the event. That being said, if the school holidays start on a Sunday or Monday, the weekend before that school holiday is included in the total event time. The same applies to the end date. The weekend after a school holiday is included if the holiday ends on a Friday or Sunday.
-4. **What location is given to the event?** A school holiday is an area event, it scopes to either locality, county, region, or country level. For example, school holidays in the United States are scoped to the district level which means we have school holidays per district while school holidays in New Zealand are scoped to the country level which means we have one school holiday for the entire country, e.g. [Spring School Holidays.](https://control.predicthq.com/search/events/SPVWqTnhTqry2rLDvf) School holidays in the UK are scoped to the local council level. The latitude and longitude are pointing to the center of the country, region, county, or locality.
+4. **What location is given to the event?** A school holiday is an area event, it scopes to either locality, county, region, or country level. For example, school holidays in the United States are scoped to the district level which means we have school holidays per district while school holidays in New Zealand are scoped to the country level which means we have one school holiday for the entire country, e.g. [Spring School Holidays.](https://events.predicthq.com/events/SPVWqTnhTqry2rLDvf) School holidays in the UK are scoped to the local council level. The latitude and longitude are pointing to the center of the country, region, county, or locality.
 5. **Teacher Only Days -** We do not currently include teacher-only days.
 
 #### Geoscoping
@@ -195,21 +195,21 @@ School holidays for the rest of the world, and from the US and UK before the tim
 
 ### Observances
 
-An Observance is a day that is recognized nationally or internationally, usually set by a major organization or government to commemorate a public health or ethical cause of importance on a national or international level. E.g. [Mother’s Day](https://control.predicthq.com/search/events/XLGbVwXCopCg2rnN89), [New Year’s Eve](https://control.predicthq.com/search/events/9sHnCzcaMEK3tRu9Wr), [World Cancer Day](https://control.predicthq.com/search/events/3jHMpFmP4Q5NEjGxMj), etc
+An Observance is a day that is recognized nationally or internationally, usually set by a major organization or government to commemorate a public health or ethical cause of importance on a national or international level. E.g. [Mother’s Day](https://events.predicthq.com/events/XLGbVwXCopCg2rnN89), [New Year’s Eve](https://events.predicthq.com/events/9sHnCzcaMEK3tRu9Wr), [World Cancer Day](https://events.predicthq.com/events/3jHMpFmP4Q5NEjGxMj), etc
 
 **Labels**
 
 Labels for an observance event provide more information about the event. The most common 5 labels are:
 
 1. `observance-season`
-   * When the observance marks the seasonal change: [June Solstice](https://control.predicthq.com/search/events/dV6eJatmAjBpT9dwAf), [March Equinox](https://control.predicthq.com/search/events/kKqJaTbuZhRvZVkQLv), [September Equinox](https://control.predicthq.com/search/events/bPsTpsswkpRfGq73Fu), [December Solstice](https://control.predicthq.com/search/events/5eVGwA82bfPEMdHXrM).
+   * When the observance marks the seasonal change: [June Solstice](https://events.predicthq.com/events/dV6eJatmAjBpT9dwAf), [March Equinox](https://events.predicthq.com/events/kKqJaTbuZhRvZVkQLv), [September Equinox](https://events.predicthq.com/events/bPsTpsswkpRfGq73Fu), [December Solstice](https://events.predicthq.com/events/5eVGwA82bfPEMdHXrM).
    * 227 countries observed the above four types of events.
-2. `holiday-religious`: When observing a religious holiday mostly celebrated in other cultures but not a major trend among the local population. E.g. Eid al-Fitr is celebrated as a [religious public holiday](https://control.predicthq.com/search/events/rasnhTdtREXDVNb5aF) in Muslim countries and is [observed](https://control.predicthq.com/search/events/aY7JYozjyDx35umEwG) in other countries.
-3. `holiday-christian`: When observing a Christian-related holiday, e.g. [Epiphany](https://control.predicthq.com/search/events/cMjzGaEAKnCWLTG4Lc).
+2. `holiday-religious`: When observing a religious holiday mostly celebrated in other cultures but not a major trend among the local population. E.g. Eid al-Fitr is celebrated as a [religious public holiday](https://events.predicthq.com/events/rasnhTdtREXDVNb5aF) in Muslim countries and is [observed](https://events.predicthq.com/events/aY7JYozjyDx35umEwG) in other countries.
+3. `holiday-christian`: When observing a Christian-related holiday, e.g. [Epiphany](https://events.predicthq.com/events/cMjzGaEAKnCWLTG4Lc).
 4. `observance-united-nations`:
-   * The United Nations created international days to promote global awareness and action on some issues. For example, March 22 is[ World Water Day](https://control.predicthq.com/search/events/NDj4W65XpbLLeA9kPu).
-   * The United Nations also observes anniversaries of key events in its history. E.g. May 8th is [Time of Remembrance and Reconciliation for Those Who Lost Their Lives during the Second World War](https://control.predicthq.com/search/events/nLoWsBHWpVrHuW5FcC).
-5. `holiday-hebrew`: When observing a Hebrew-related holiday, e.g. many countries observe [Tu Bishvat](https://control.predicthq.com/search/events/FRgcTikSuwrJixHDdL).
+   * The United Nations created international days to promote global awareness and action on some issues. For example, March 22 is[ World Water Day](https://events.predicthq.com/events/NDj4W65XpbLLeA9kPu).
+   * The United Nations also observes anniversaries of key events in its history. E.g. May 8th is [Time of Remembrance and Reconciliation for Those Who Lost Their Lives during the Second World War](https://events.predicthq.com/events/nLoWsBHWpVrHuW5FcC).
+5. `holiday-hebrew`: When observing a Hebrew-related holiday, e.g. many countries observe [Tu Bishvat](https://events.predicthq.com/events/FRgcTikSuwrJixHDdL).
 
 #### Date & Time
 
@@ -229,10 +229,10 @@ Observances have event group entities available.
 
 **PHQ Rank**
 
-* **Rank 80-90** observances are widely observed and typically associated with consumer spending on gifts, travel, and festivities. Examples include [Valentine's Day](https://control.predicthq.com/search/events/x957f7DyXpeCubLpWH) and [Christmas Eve](https://control.predicthq.com/search/events/AtVVBpX4bkXhLDNjBa).
-* **Rank 60-79** observances are mostly religious observances, national days, independence days, or cultural and historical dates which have a wide impact. Examples include [Constitution Day](https://control.predicthq.com/search/events/PmW2kvCVoxQ3AHgAZS) and [Ganesh Chaturthi](https://control.predicthq.com/search/events/N22YXJKJlGwL).
-* **Rank 40-59** observances include observances with the potential for increased localized economic activities such as awareness days, smaller historical observances, and regional celebrations. Examples include [Queensland Day](https://control.predicthq.com/search/events/4CJKDjxdQb5RCyckrN) and [National Indigenous Peoples Day](https://control.predicthq.com/search/events/AYd5LmshmHX5zjjc4k).
-* **Rank 20-39** observances generally do not have widespread commercialization, public holidays, or significant consumer behavior changes associated with them. Examples include [September Equinox](https://control.predicthq.com/search/events/wjjJldkg0jGj) and [World Bicycle Day](https://control.predicthq.com/search/events/Bkgr5cvHLa8ZEGNUbT).
+* **Rank 80-90** observances are widely observed and typically associated with consumer spending on gifts, travel, and festivities. Examples include [Valentine's Day](https://events.predicthq.com/events/x957f7DyXpeCubLpWH) and [Christmas Eve](https://events.predicthq.com/events/AtVVBpX4bkXhLDNjBa).
+* **Rank 60-79** observances are mostly religious observances, national days, independence days, or cultural and historical dates which have a wide impact. Examples include [Constitution Day](https://events.predicthq.com/events/PmW2kvCVoxQ3AHgAZS) and [Ganesh Chaturthi](https://events.predicthq.com/events/N22YXJKJlGwL).
+* **Rank 40-59** observances include observances with the potential for increased localized economic activities such as awareness days, smaller historical observances, and regional celebrations. Examples include [Queensland Day](https://events.predicthq.com/events/4CJKDjxdQb5RCyckrN) and [National Indigenous Peoples Day](https://events.predicthq.com/events/AYd5LmshmHX5zjjc4k).
+* **Rank 20-39** observances generally do not have widespread commercialization, public holidays, or significant consumer behavior changes associated with them. Examples include [September Equinox](https://events.predicthq.com/events/wjjJldkg0jGj) and [World Bicycle Day](https://events.predicthq.com/events/Bkgr5cvHLa8ZEGNUbT).
 
 **Local Rank**
 
@@ -263,7 +263,7 @@ Note: Datetime is used with the local timezone.
 
 #### Location
 
-Politics events scope to a country level. For example [Election for the President of the United States of America](https://control.predicthq.com/search/events/U9Q6MExfzBmwgjAXBE) in the United States. The latitude and longitude point to the center of the covered area. The place scope will identify the full area of coverage.
+Politics events scope to a country level. For example [Election for US Senate](https://events.predicthq.com/events/U9Q6MExfzBmwgjAXBE) in the United States. The latitude and longitude point to the center of the covered area. The place scope will identify the full area of coverage.
 
 #### Entities
 

--- a/docs/tech-docs/getting-started/predicthq-data/event-categories/unscheduled-events.md
+++ b/docs/tech-docs/getting-started/predicthq-data/event-categories/unscheduled-events.md
@@ -12,12 +12,12 @@ description: >-
 
 Severe weather is any dangerous meteorological phenomenon with the potential to cause damage, serious social disruption, or loss of human life. Types of severe weather phenomena vary, depending on the latitude, altitude, topography, and atmospheric conditions.
 
-Severe weather warnings or alerts which may lead to disruption. Severe weather alerts include storms, extreme temperature, flood, etc. For example, a [tornado warning](https://control.predicthq.com/search/events/v3xwuouU62ZEzXhxWC) for southeastern Webster Parish in northwestern Louisiana alerts people that a severe thunderstorm along with damage in the nearby area is likely to occur in the upcoming hour.
+Severe weather warnings or alerts which may lead to disruption. Severe weather alerts include storms, extreme temperature, flood, etc. For example, a [tornado warning](https://events.predicthq.com/events/v3xwuouU62ZEzXhxWC) for southeastern Webster Parish in northwestern Louisiana alerts people that a severe thunderstorm along with damage in the nearby area is likely to occur in the upcoming hour.
 
 Severe weather storm events can change over time. Events like hurricanes, tornados and other storms move across different locations and change in strength as time goes on. This can be reflected by different warning events in our system. It’s possible to have multiple warnings about the same weather condition:
 
-* The bad weather condition lasts longer than expected. For example, a [flood advisory was issued at 11.48 AM](https://control.predicthq.com/search/events/jZEkmbAYqntSRo4Xgs) in east Tennessee that the potential threat may last until 3 PM. Another [flood advisory issued at 3.02 PM](https://control.predicthq.com/search/events/fxZjGT5Ehoe7brsCjd) that indicates additional rainfall may occur on the day and the following day, and the road closures will remain in place.
-* Multiple areas can be affected. For example, On March 14th, several regions in South Dakota have issued blizzard warnings, such as [Oglala Lakota](https://control.predicthq.com/search/events/tTjDpN7ZR2WVhzw47o), [Pennington](https://control.predicthq.com/search/events/ubp47jnAvuwos5fanc), [Fall River](https://control.predicthq.com/search/events/74ucjeYRYWG89Sw5rS), and [Custer](https://control.predicthq.com/search/events/6y3py8CPSLfeN29DYq).
+* The bad weather condition lasts longer than expected. For example, a [flood advisory was issued at 11.48 AM](https://events.predicthq.com/events/jZEkmbAYqntSRo4Xgs) in east Tennessee that the potential threat may last until 3 PM. Another [flood advisory issued at 3.02 PM](https://events.predicthq.com/events/fxZjGT5Ehoe7brsCjd) that indicates additional rainfall may occur on the day and the following day, and the road closures will remain in place.
+* Multiple areas can be affected. For example, On March 14th, several regions in South Dakota have issued blizzard warnings, such as [Oglala Lakota](https://events.predicthq.com/events/tTjDpN7ZR2WVhzw47o), [Pennington](https://events.predicthq.com/events/ubp47jnAvuwos5fanc), [Fall River](https://events.predicthq.com/events/74ucjeYRYWG89Sw5rS), and [Custer](https://events.predicthq.com/events/6y3py8CPSLfeN29DYq).
 * Warnings may be issued hours or days in advance. The event (warning) state will change to `cancelled` if the potential threat no longer exist. For example the storm didn't hit as expected. Past events with an `active` state mean the event has happened.
 * Severe weather data is updated in near real time with event details being refreshed on average every 15 mins.
 * PredictHQ provides historical severe weather data that can be used for purposes like training a demand forecasting model.
@@ -92,7 +92,7 @@ This category is classified into three buckets with the following labels used to
     `fire`, `wildfire`, `drought`
 3.  **Lockdown**
 
-    The government mandated stay-at-home orders during the COVID-19 pandemic that restrict or reduce social activities on different levels. Lockdown events have `health`, `lockdown` and `disaster` labels. For example, [COVID-19 - Lockdown easing - Portugal](https://control.predicthq.com/search/events/ydXTVviY5KQty98UfD), [COVID-19 - Stay at home order easing - Michigan - Phase 4](https://control.predicthq.com/search/events/Vat8acyAFAXQaNNTaK).
+    The government mandated stay-at-home orders during the COVID-19 pandemic that restrict or reduce social activities on different levels. Lockdown events have `health`, `lockdown` and `disaster` labels. For example, [COVID-19 - Lockdown easing - Portugal](https://events.predicthq.com/events/ydXTVviY5KQty98UfD), [COVID-19 - Stay at home order easing - Michigan - Phase 4](https://events.predicthq.com/events/Vat8acyAFAXQaNNTaK).
 
 #### Date & Time
 
@@ -236,10 +236,10 @@ An act of terrorism committed using violence against civilians, with the intenti
 Labels for a terror event provide more information about the event. The most common 5 labels are:
 
 1. `attack`: An aggressive and violent act against a person or place with weapons or armed force.
-2. `bombing` : The terrorism acts where the main injury or damage is caused by dropping or detonating a bomb somewhere, for example, [Bombing in Lahan, Nepal](https://control.predicthq.com/search/events/hnCL2axLWVJZyBN2AV).
+2. `bombing` : The terrorism acts where the main injury or damage is caused by dropping or detonating a bomb somewhere, for example, [Bombing in Lahan, Nepal](https://events.predicthq.com/events/hnCL2axLWVJZyBN2AV).
 3. `arson`: The terrorism acts also result in a fire damage, it may it may be combined with a `shooting`, `bombing`, etc.
-4. `hostage-crisis`: The terrorism acts when the hostage occurs, for example, [`assassination`](https://control.predicthq.com/search/events/ywfjG46u6KDmkqqsAa), a terror threat, etc.
-5. `shooting`: The terrorism acts where the main injury or damage is caused by shooting, for example, [Shooting in Sonwar, India](https://control.predicthq.com/search/events/X6D8sz2i7qWZ3VMpFh). If the shooting is on a larger scale, the `mass-shooting` label will be added, for example, [Shooting in Chicago, United States](https://control.predicthq.com/search/events/FtzZisWG6r8KZRp9Gp).
+4. `hostage-crisis`: The terrorism acts when the hostage occurs, for example, [`assassination`](https://events.predicthq.com/events/ywfjG46u6KDmkqqsAa), a terror threat, etc.
+5. `shooting`: The terrorism acts where the main injury or damage is caused by shooting, for example, [Shooting in Sonwar, India](https://events.predicthq.com/events/X6D8sz2i7qWZ3VMpFh). If the shooting is on a larger scale, the `mass-shooting` label will be added, for example, [Shooting in Chicago, United States](https://events.predicthq.com/events/FtzZisWG6r8KZRp9Gp).
 
 #### Date & Time
 
@@ -249,7 +249,7 @@ Note: Datetime is in UTC
 
 #### Location
 
-Terror events are tracked as an event with a scope of locality. In terms of geographic information we return a latitude/longitude for the event and the address of the event. However, terror events can apply to a wider area, for example, [attempted bombing in Cipinang, Indonesia](https://control.predicthq.com/search/events/VGG78MrBvgZ4dartjv).
+Terror events are tracked as an event with a scope of locality. In terms of geographic information we return a latitude/longitude for the event and the address of the event. However, terror events can apply to a wider area, for example, [attempted bombing in Cipinang, Indonesia](https://events.predicthq.com/events/VGG78MrBvgZ4dartjv).
 
 #### Entities
 

--- a/docs/tech-docs/getting-started/predicthq-data/ranks/local-rank.md
+++ b/docs/tech-docs/getting-started/predicthq-data/ranks/local-rank.md
@@ -1,6 +1,6 @@
 # Local Rank
 
-Local Rank is a numeric value on a logarithmic scale between 0 and 100 to represent the impact of an event to its local area. Local Rank may vary even though the PHQ Rank of the events are the same. For example, a conference with 1,000 people in attendance (with PHQ Rank 50) has a [Local Rank of 43 in Hong Kong](https://control.predicthq.com/search/events/KKtBoCYP3gWPvgGhnp) where the local population density is around 64,000, while a [Local Rank of 65 in Dublin, Ireland](https://control.predicthq.com/search/events/0lrweBnDZKrr) where the local population density is around 5,000.
+Local Rank is a numeric value on a logarithmic scale between 0 and 100 to represent the impact of an event to its local area. Local Rank may vary even though the PHQ Rank of the events are the same. For example, a conference with 1,000 people in attendance (with PHQ Rank 50) has a [Local Rank of 43 in Hong Kong](https://events.predicthq.com/events/KKtBoCYP3gWPvgGhnp) where the local population density is around 64,000, while a [Local Rank of 65 in Dublin, Ireland](https://events.predicthq.com/events/0lrweBnDZKrr) where the local population density is around 5,000.
 
 * Local Rank is comparable between the attended events in terms of the event’s impact to its local area.
 * Local Rank is not available for area events, the field returns `null`.


### PR DESCRIPTION
A lot of links to example events point to webapp, where users (including trial plan) might not be able to see them due to subscription limitations. Updating these to go to public event pages. 

https://predicthq.atlassian.net/browse/SE-2302